### PR TITLE
Back to starting location in Build.ps1

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -5,6 +5,7 @@ using module .\CoreLibrary.psm1
 
 cls;
 
+$initialLocation = Get-Location;
 Set-Location $PSScriptRoot;
 
 [bool]$DEBUG = $true;
@@ -191,3 +192,5 @@ foreach ($remoteHost in $hostCatalogs) {
         Body = $script.body;
     });
 }
+
+Set-Location $initialLocation;


### PR DESCRIPTION
Move back to the starting location after all.
Required if you wanna to run script normally from the shell.